### PR TITLE
Publish Views to allow them to be overwritten.

### DIFF
--- a/src/Providers/LaravelGovernorServiceProvider.php
+++ b/src/Providers/LaravelGovernorServiceProvider.php
@@ -41,6 +41,7 @@ class LaravelGovernorServiceProvider extends AggregateServiceProvider
         $this->publishes([__DIR__ . '/../../config/config.php' => config_path('genealabs-laravel-governor.php')], 'genealabs-laravel-governor');
         $this->publishes([__DIR__ . '/../../public' => public_path('genealabs-laravel-governor')], 'genealabs-laravel-governor');
         $this->loadViewsFrom(__DIR__ . '/../../resources/views', 'genealabs-laravel-governor');
+        $this->publishes([__DIR__ . '/../../resources/views' => resource_path('views/vendor/genealabs-laravel-governor')], 'genealabs-laravel-governor');
     }
 
     /**


### PR DESCRIPTION
Closes #15.

The only caveat I can see with this is it will publish the default layout and master intermediary, but not update the views to reflect their new locations. (At least, I don't think Laravel can do that anyway...) Some kind of warning will need to be put in the documentation about that.
